### PR TITLE
[add] asm to extension list

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "languages": [{
             "id": "gas",
             "aliases": ["GAS/AT&T x86/x64", "gas"],
-            "extensions": [".s",".S",".sx"],
+            "extensions": [".s",".S",".sx", "asm"],
             "configuration": "./language-configuration.json"
         }],
         "grammars": [{

--- a/syntaxes/gas.tmLanguage
+++ b/syntaxes/gas.tmLanguage
@@ -7,6 +7,7 @@
 		<string>s</string>
 		<string>S</string>
 		<string>sx</string>
+		<string>asm</string>
 	</array>
 	<key>name</key>
 	<string>GAS/AT&amp;T x86/x64</string>


### PR DESCRIPTION
Hello, thanks for this very useful extension.
I added "asm", which is often used as an extension for assembly language, to the list of extensions.

Search results on GitHub:
https://github.com/search?q=language%3Aasm&type=Code

However, I am not familiar with the custom in `gas`, so this change may not be appropriate.
Therefore, I respect your final decision.