### PR TITLE
add ".asm" to file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "languages": [{
             "id": "gas",
             "aliases": ["GAS/AT&T x86/x64", "gas"],
-            "extensions": [".s",".S",".sx"],
+            "extensions": [".s",".S",".sx",".asm"],
             "configuration": "./language-configuration.json"
         }],
         "grammars": [{


### PR DESCRIPTION
Based on the issue #7, I saw that ".asm" files weren't recognized by the "package.json". This is why the extension didn't work for me. Now I have added support for ".asm" files.
